### PR TITLE
Uninstall routine for shop-connector setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,14 +16,6 @@ atlassian-ide-plugin.xml
 
 
 # +-----------------------------+
-# | Shop-Connector install logs |
-# +-----------------------------+
-
-shop-connector/setup/logs/*
-
-
-
-# +-----------------------------+
 # |      Keep all .gitkeep      |
 # |-----------------------------+----------------------------------------------+
 # | Keep this at the bottom of this .gitignore.                                |

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,22 @@ atlassian-ide-plugin.xml
 
 .DS_Store
 
+
+
+# +-----------------------------+
+# | Shop-Connector install logs |
+# +-----------------------------+
+
+shop-connector/setup/logs/*
+
+
+
+# +-----------------------------+
+# |      Keep all .gitkeep      |
+# |-----------------------------+----------------------------------------------+
+# | Keep this at the bottom of this .gitignore.                                |
+# | Ignore a direcotrys contents with an asterisk (/dir/*) and put a .gitkeep  |
+# | in this directory to keep an empty directory in your repository.           |
+# +----------------------------------------------------------------------------+
+
+!.gitkeep

--- a/shop-connector/setup.php
+++ b/shop-connector/setup.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 require 'setup/bootstrap.php';

--- a/shop-connector/setup/Logger/Exception/LogAlreadyExistsException.php
+++ b/shop-connector/setup/Logger/Exception/LogAlreadyExistsException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Logger\Exception;
+
+class LogAlreadyExistsException extends \Exception
+{
+
+
+}

--- a/shop-connector/setup/Logger/Logger.php
+++ b/shop-connector/setup/Logger/Logger.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Logger;
+
+class Logger
+{
+    /** @var String */
+    protected $_logFile;
+
+    /** @var resource */
+    protected $_fileHandle;
+
+    /**
+     * @param $file
+     */
+    public function __construct($file)
+    {
+        $this->_logFile = $file;
+    }
+
+    /** */
+    public function __destruct()
+    {
+        $fh = $this->_fileHandle;
+
+        if (is_resource($fh)) {
+            echo "[Logger] Close logfile: " . $this->_logFile . "\n";
+            fclose($fh);
+        }
+    }
+
+    public function log($message)
+    {
+        $fh = $this->_fileHandle;
+
+        // open logfile on demand
+        if (!is_resource($fh)) {
+            echo "[Logger] Open logfile: " . $this->_logFile . "\n";
+            $fh = $this->_lOpen();
+        }
+
+        fwrite($fh, $message . PHP_EOL);
+    }
+
+    /**
+     * @return resource
+     */
+    protected function _lOpen()
+    {
+        $logFile = $this->_logFile;
+        $fh = fopen($logFile, 'a') or exit("Can't open logfile: " . $logFile);
+        $this->_fileHandle = $fh;
+
+        return $fh;
+    }
+
+}

--- a/shop-connector/setup/Logger/Logger.php
+++ b/shop-connector/setup/Logger/Logger.php
@@ -2,6 +2,8 @@
 
 namespace Logger;
 
+use Logger\Exception\LogAlreadyExistsException;
+
 class Logger
 {
     /** @var String */
@@ -11,11 +13,17 @@ class Logger
     protected $_fileHandle;
 
     /**
-     * @param $file
+     * @param $logFile
+     *
+     * @throws Exception\LogAlreadyExistsException
      */
-    public function __construct($file)
+    public function __construct($logFile)
     {
-        $this->_logFile = $file;
+        if (file_exists($logFile)) {
+            throw new LogAlreadyExistsException("Log '$logFile' already exists");
+        }
+
+        $this->_logFile = $logFile;
     }
 
     /** */
@@ -24,18 +32,19 @@ class Logger
         $fh = $this->_fileHandle;
 
         if (is_resource($fh)) {
-            echo "[Logger] Close logfile: " . $this->_logFile . "\n";
             fclose($fh);
         }
     }
 
+    /**
+     * @param $message
+     */
     public function log($message)
     {
         $fh = $this->_fileHandle;
 
         // open logfile on demand
         if (!is_resource($fh)) {
-            echo "[Logger] Open logfile: " . $this->_logFile . "\n";
             $fh = $this->_lOpen();
         }
 
@@ -44,10 +53,12 @@ class Logger
 
     /**
      * @return resource
+     * @throws Exception\LogAlreadyExistsException
      */
     protected function _lOpen()
     {
         $logFile = $this->_logFile;
+
         $fh = fopen($logFile, 'a') or exit("Can't open logfile: " . $logFile);
         $this->_fileHandle = $fh;
 

--- a/shop-connector/setup/Setup/Exception/LogfileNotFoundException.php
+++ b/shop-connector/setup/Setup/Exception/LogfileNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Setup\Exception;
+
+class LogfileNotFoundException extends \Exception
+{
+
+
+}

--- a/shop-connector/setup/bootstrap.php
+++ b/shop-connector/setup/bootstrap.php
@@ -19,20 +19,10 @@ use Setup\CliSetup;
 use Setup\WebSetup;
 
 
-
-
-
 if (Setup::onCLI()) {
     $setup = new CliSetup();
 } else {
     $setup = new WebSetup();
 }
-
-//try {
-//    $setup->run();
-//} catch (ShopNotFoundException $e) {
-//    $this->_println($e->getMessage());
-//    exit(1);
-//}
 
 $setup->run();


### PR DESCRIPTION
Added an uninstall routine for shop-connector setup.
- Force an installation with parameter -f or --force (old installation will be removed before installing new files)
- Uninstall with parameter -u or --uninstall

Setup will write an install log to the install directory. This will be used to detect a present installation and for uninstallation.
