### PR TITLE
Added version layer for eShop v4.8

### DIFF
--- a/shop-connector/OXID/core/VersionLayer480.php
+++ b/shop-connector/OXID/core/VersionLayer480.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once getShopBasePath() . 'core/VersionLayer470.php';
+
+class VersionLayer480 extends VersionLayer470
+{
+}


### PR DESCRIPTION
With eShop version 4.8.x no version layer was found. This is now fixed.
